### PR TITLE
Fix overlay not shown after tour complete/cancelled

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -172,7 +172,9 @@ export class Step extends Evented {
    * Hide the step
    */
   hide() {
-    this.tour.modal.hide();
+    if (this.tour.modal) {
+      this.tour.modal.hide();
+    }
 
     this.trigger('before-hide');
 

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -292,6 +292,7 @@ export class Tour extends Evented {
 
         if (modalContainer) {
           modalContainer.remove();
+          this.modal = null;
         }
       }
     }


### PR DESCRIPTION
Overlay is not appearing again if tour was completed/cancelled.

Bug reproduction steps:

1. Start tour with `useModalOverlay: true` option
2. Complete tour
3. Try to show any step using `tour.show()`


Solution:

If modal container removed - remove modal object too. Otherwise modal container not appearing again.