### PR TITLE
Focus on render will trigger only once

### DIFF
--- a/src/js/utils/general.js
+++ b/src/js/utils/general.js
@@ -106,7 +106,8 @@ export function getPopperOptions(attachToOptions, step) {
         phase: 'afterWrite',
         fn() {
           setTimeout(() => {
-            if (step.el) {
+            if (step.el && !step.el.hasAttribute('data-shepherd-focus-after-render')) {
+              step.el.setAttribute('data-shepherd-focus-after-render', true);
               step.el.focus();
             }
           }, 300);

--- a/src/js/utils/popper-options.js
+++ b/src/js/utils/popper-options.js
@@ -59,7 +59,8 @@ export function makeCenteredPopper(step) {
         phase: 'afterWrite',
         fn() {
           setTimeout(() => {
-            if (step.el) {
+            if (step.el && !step.el.hasAttribute('data-shepherd-focus-after-render', true)) {
+              step.el.setAttribute('data-shepherd-focus-after-render');
               step.el.focus();
             }
           }, 300);


### PR DESCRIPTION
To address https://github.com/shipshapecode/shepherd/issues/1368, the focus after Popper init happens only once, so Popper doesn't refocus back to the dialog after every scroll/resize event.