### PR TITLE
Fix: FloatingUI arrow() padding

### DIFF
--- a/src/js/utils/floating-ui.js
+++ b/src/js/utils/floating-ui.js
@@ -187,7 +187,9 @@ export function getFloatingUIOptions(attachToOptions, step) {
     );
 
     if (arrowEl) {
-      options.middleware.push(arrow({ element: arrowEl }));
+      const arrowPadding = getPaddingSum(step.options.floatingUIOptions.middleware || []);
+
+      options.middleware.push(arrow({ element: arrowEl, padding: arrowPadding}));
     }
 
     options.placement = attachToOptions.on;
@@ -206,4 +208,27 @@ function addArrow(step) {
   }
 
   return false;
+}
+
+/**
+ *
+ * @param {Object[]} middleware
+ * @returns {number}
+ */
+function getPaddingSum(middleware) {
+  const arrowFunctions = middleware.filter(isUnusedArrowFunction);
+  let sum = 0;
+  arrowFunctions.forEach((func)=> {
+    sum += func.options.padding;
+  })
+  return sum;
+}
+
+/**
+ *
+ * @param {Object} el
+ * @returns {boolean}
+ */
+function isUnusedArrowFunction(el) {
+  return el.name === "arrow" && el.options.element === null;
 }


### PR DESCRIPTION
Related to https://github.com/shipshapecode/shepherd/issues/2302 

Arrow function passed through a step's middleware will have a null element, in which case the padding will not be applied. Sum up all such occurrences and pass the final padding to the arrow function with the newly added arrow element.

It allows arrow() passed from step middleware to actually be applied. Perhaps it could be cut down and done through a function passed to merge(), but I'm not familiar with that library.

Can write some tests for it, though I think this more of a bug fix for behavior that should already be working than new functionality. If not, I think the docs should be updated to specify which floatingUI options/middleware functions are accepted/work.