### PR TITLE
fix: show overlay again after cancel

### DIFF
--- a/src/js/step.js
+++ b/src/js/step.js
@@ -1,5 +1,6 @@
 import merge from 'deepmerge';
 import { Evented } from './evented.js';
+import { Shepherd } from './tour.js';
 import autoBind from './utils/auto-bind.js';
 import {
   isElement,
@@ -179,7 +180,9 @@ export class Step extends Evented {
    * Hide the step
    */
   hide() {
-    this.tour.modal.hide();
+    if (this.tour.modal) {
+      this.tour.modal.hide();
+    }
 
     this.trigger('before-hide');
 
@@ -401,6 +404,10 @@ export class Step extends Evented {
 
     if (!this.tour.modal) {
       this.tour._setupModal();
+    }
+
+    if (Shepherd.activeTour != this.tour) {
+      this.tour._setupActiveTour()
     }
 
     this.tour.modal.setupForStep(this);

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -405,7 +405,7 @@ export class Step extends Evented {
     }
 
     if (Shepherd.activeTour !== this.tour) {
-      this.tour._setupActiveTour()
+      this.tour._setupActiveTour();
     }
 
     this.tour.modal.setupForStep(this);

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -180,9 +180,7 @@ export class Step extends Evented {
    * Hide the step
    */
   hide() {
-    if (this.tour.modal) {
-      this.tour.modal.hide();
-    }
+    this.tour.modal?.hide();
 
     this.trigger('before-hide');
 

--- a/src/js/step.js
+++ b/src/js/step.js
@@ -404,7 +404,7 @@ export class Step extends Evented {
       this.tour._setupModal();
     }
 
-    if (Shepherd.activeTour != this.tour) {
+    if (Shepherd.activeTour !== this.tour) {
       this.tour._setupActiveTour()
     }
 

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -315,7 +315,7 @@ export class Tour extends Evented {
 
         if (modalContainer) {
           modalContainer.remove();
-          this.modal = null
+          this.modal = null;
         }
       }
     }

--- a/src/js/tour.js
+++ b/src/js/tour.js
@@ -315,6 +315,7 @@ export class Tour extends Evented {
 
         if (modalContainer) {
           modalContainer.remove();
+          this.modal = null
         }
       }
     }


### PR DESCRIPTION
If the tour was cancelled at some point the overlay is only shown if you use `tour.start()` if you want to continue the tour afterwards (`tour.next()` or `tour.show(x)` the overlay is missing.

While i get that you __should__ use `tour.start()` after the tour is done, i don't really want to go through everything from the beginning again if i cancel mid tour... especially not since `tour.getCurrentStep()` keeps reporting the last step before the tour was cancelled.

This fixes the need of a workaround by manually calling `_setupActiveTour` and `_setupModal` when the tour was cancelled and should be resumed.

EDIT: oh well... this is basically a enhanced version of https://github.com/shipshapecode/shepherd/pull/1237 

EDIT2: Since you where talking about "coming up with a good fix" in the pull-request linked above... i'm not sure if this would be considered a "good" fix. It's a fix without changing to much of the existing code. 

a proposed "better" fix (which requires a bit more changes to the code) might be:

- move the setup part of `tour.start()` logic in a `_init` function
- keep track of the `initialized` state which then will be reset in `_done`
- when calling `step.show()` make sure to check if `initialized` is still valid, else fire `_init` again

That would do more or less the same, but IF something should change on the `start/setup` part it would only require one place to keep updated