### PR TITLE
Related to #2399, also stop keydown default behavior when navigation is enabled

### DIFF
--- a/src/js/components/shepherd-element.svelte
+++ b/src/js/components/shepherd-element.svelte
@@ -92,18 +92,21 @@
         break;
       case KEY_ESC:
         if (tour.options.exitOnEsc) {
+          e.preventDefault();
           e.stopPropagation();
           step.cancel();
         }
         break;
       case LEFT_ARROW:
         if (tour.options.keyboardNavigation) {
+          e.preventDefault();
           e.stopPropagation();
           tour.back();
         }
         break;
       case RIGHT_ARROW:
         if (tour.options.keyboardNavigation) {
+          e.preventDefault();
           e.stopPropagation();
           tour.next();
         }


### PR DESCRIPTION
This is a patch for #2399 that stops key ESC, Left-Arrow, and Right-Arrow propagation.
This patch is to also stop the default behavior for those keys when navigation is enabled.
