### PR TITLE
Ship both cjs and esm

### DIFF
--- a/shepherd.js/package.json
+++ b/shepherd.js/package.json
@@ -21,10 +21,14 @@
   "exports": {
     ".": {
       "types": "./dist/shepherd.d.ts",
+      "require": "./dist/shepherd.js",
+      "import": "./dist/shepherd.mjs",
       "default": "./dist/shepherd.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs",
       "default": "./dist/*.js"
     }
   },

--- a/shepherd.js/rollup.config.mjs
+++ b/shepherd.js/rollup.config.mjs
@@ -78,7 +78,16 @@ export default [
     output: [
       {
         dir: 'dist',
+        entryFileNames: '[name].mjs',
         format: 'es',
+        exports: 'named',
+        sourcemap: true
+      },
+      {
+        dir: 'dist',
+        entryFileNames: '[name].js',
+        format: 'cjs',
+        exports: 'named',
         sourcemap: true
       }
     ],


### PR DESCRIPTION
This should fix issues with things like Next.js that do not correctly identify ESM when it has a `.js` extension.