### PR TITLE
Remove NoOp type usage

### DIFF
--- a/landing/src/layouts/MainPage.astro
+++ b/landing/src/layouts/MainPage.astro
@@ -11,6 +11,7 @@ const shepherdIncludeCode = `
 	<script type="module" src="shepherd.js/dist/shepherd.mjs"></script>
   
 `;
+import type { StepOptions } from 'shepherd.js/step';
 ---
 
 <Base>
@@ -174,6 +175,7 @@ const shepherdIncludeCode = `
   'use strict';
 
   import Shepherd from 'shepherd.js';
+import type { StepOptions } from 'shepherd.js/step';
   import type { Tour } from 'shepherd.js/tour';
 
   (function () {
@@ -191,7 +193,6 @@ const shepherdIncludeCode = `
     }
 
     function setupShepherd() {
-      // @ts-expect-error TODO
       const shepherd = new Shepherd.Tour({
         id: 'ts4udfrnm7o95ny7e9qbjo3t',
         defaultStepOptions: {
@@ -238,7 +239,7 @@ const shepherdIncludeCode = `
         'Including Shepherd is easy! Just include shepherd.js. The styles are bundled with the JS.';
 
       // These steps should be added via `addSteps`
-      const steps = [
+      const steps: Array<StepOptions> = [
         {
           title: 'Including',
           text: element,

--- a/shepherd.js/src/shepherd.ts
+++ b/shepherd.js/src/shepherd.ts
@@ -1,10 +1,7 @@
 import { Shepherd, Tour } from './tour.ts';
-import { StepNoOp, TourNoOp } from './utils/general.ts';
 import { Step } from './step.ts';
 
-const isServerSide = typeof window === 'undefined';
-
-Shepherd.Step = isServerSide ? StepNoOp : Step;
-Shepherd.Tour = isServerSide ? TourNoOp : Tour;
+Shepherd.Step = Step;
+Shepherd.Tour = Tour;
 
 export default Shepherd;

--- a/shepherd.js/src/shepherd.ts
+++ b/shepherd.js/src/shepherd.ts
@@ -4,7 +4,7 @@ import { Step } from './step.ts';
 
 const isServerSide = typeof window === 'undefined';
 
-Shepherd.Step = isServerSide ? StepNoOp : Step;
-Shepherd.Tour = isServerSide ? TourNoOp : Tour;
+Shepherd.Step = (isServerSide ? StepNoOp : Step) as unknown as typeof Step;
+Shepherd.Tour = (isServerSide ? TourNoOp : Tour) as unknown as typeof Tour;
 
 export default Shepherd;

--- a/shepherd.js/src/shepherd.ts
+++ b/shepherd.js/src/shepherd.ts
@@ -1,7 +1,10 @@
 import { Shepherd, Tour } from './tour.ts';
+import { StepNoOp, TourNoOp } from './utils/general.ts';
 import { Step } from './step.ts';
 
-Shepherd.Step = Step;
-Shepherd.Tour = Tour;
+const isServerSide = typeof window === 'undefined';
+
+Shepherd.Step = isServerSide ? StepNoOp : Step;
+Shepherd.Tour = isServerSide ? TourNoOp : Tour;
 
 export default Shepherd;

--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -109,8 +109,8 @@ export class ShepherdPro extends Evented {
 
   // Vanilla Shepherd
   activeTour?: Tour | null;
-  declare Step: StepNoOp | Step;
-  declare Tour: TourNoOp | Tour;
+  declare Step: typeof StepNoOp | typeof Step;
+  declare Tour: typeof TourNoOp | typeof Tour;
 
   /**
    * Call init to take full advantage of ShepherdPro functionality

--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -13,6 +13,7 @@ import DataRequest from './utils/datarequest.ts';
 import { normalizePrefix, uuid } from './utils/general.ts';
 // @ts-expect-error TODO: not yet typed
 import ShepherdModal from './components/shepherd-modal.svelte';
+import type { StepNoOp, TourNoOp } from './utils/general.ts';
 
 interface Actor {
   actorId: number;
@@ -108,8 +109,8 @@ export class ShepherdPro extends Evented {
 
   // Vanilla Shepherd
   activeTour?: Tour | null;
-  declare Step: Step;
-  declare Tour: Tour;
+  declare Step: StepNoOp | Step;
+  declare Tour: TourNoOp | Tour;
 
   /**
    * Call init to take full advantage of ShepherdPro functionality

--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -109,8 +109,8 @@ export class ShepherdPro extends Evented {
 
   // Vanilla Shepherd
   activeTour?: Tour | null;
-  declare Step: typeof StepNoOp | typeof Step;
-  declare Tour: typeof TourNoOp | typeof Tour;
+  declare Step: typeof Step;
+  declare Tour: typeof Tour;
 
   /**
    * Call init to take full advantage of ShepherdPro functionality

--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -13,7 +13,6 @@ import DataRequest from './utils/datarequest.ts';
 import { normalizePrefix, uuid } from './utils/general.ts';
 // @ts-expect-error TODO: not yet typed
 import ShepherdModal from './components/shepherd-modal.svelte';
-import type { StepNoOp, TourNoOp } from './utils/general.ts';
 
 interface Actor {
   actorId: number;

--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -13,7 +13,6 @@ import DataRequest from './utils/datarequest.ts';
 import { normalizePrefix, uuid } from './utils/general.ts';
 // @ts-expect-error TODO: not yet typed
 import ShepherdModal from './components/shepherd-modal.svelte';
-import type { StepNoOp, TourNoOp } from './utils/general.ts';
 
 interface Actor {
   actorId: number;
@@ -109,8 +108,8 @@ export class ShepherdPro extends Evented {
 
   // Vanilla Shepherd
   activeTour?: Tour | null;
-  declare Step: StepNoOp | Step;
-  declare Tour: TourNoOp | Tour;
+  declare Step: Step;
+  declare Tour: Tour;
 
   /**
    * Call init to take full advantage of ShepherdPro functionality

--- a/shepherd.js/src/utils/general.ts
+++ b/shepherd.js/src/utils/general.ts
@@ -1,18 +1,5 @@
-import { type Tour, type TourOptions } from '../tour.ts';
-import {
-  type StepOptionsAttachTo,
-  type Step,
-  type StepOptions
-} from '../step.ts';
+import { type StepOptionsAttachTo, type Step } from '../step.ts';
 import { isFunction, isString } from './type-check.ts';
-
-export class StepNoOp {
-  constructor(_options: StepOptions) {}
-}
-
-export class TourNoOp {
-  constructor(_tour: Tour, _options: TourOptions) {}
-}
 
 /**
  * Ensure class prefix ends in `-`

--- a/shepherd.js/src/utils/general.ts
+++ b/shepherd.js/src/utils/general.ts
@@ -1,5 +1,18 @@
-import { type StepOptionsAttachTo, type Step } from '../step.ts';
+import { type Tour, type TourOptions } from '../tour.ts';
+import {
+  type StepOptionsAttachTo,
+  type Step,
+  type StepOptions
+} from '../step.ts';
 import { isFunction, isString } from './type-check.ts';
+
+export class StepNoOp {
+  constructor(_options: StepOptions) {}
+}
+
+export class TourNoOp {
+  constructor(_tour: Tour, _options: TourOptions) {}
+}
 
 /**
  * Ensure class prefix ends in `-`


### PR DESCRIPTION
We still have the Step and Tour NoOp classes to help with SSR, but we don't really need the types and they were causing issues.