### PR TITLE
🐛 Fixes import issues reported in 2785

### DIFF
--- a/landing/src/layouts/MainPage.astro
+++ b/landing/src/layouts/MainPage.astro
@@ -198,6 +198,10 @@ const shepherdIncludeCode = `
     }
 
     function setupShepherd() {
+      const element = document.createElement('p');
+      element.innerText =
+        'Including Shepherd is easy! Just include shepherd.js. The styles are bundled with the JS.';
+
       const shepherd = new Shepherd.Tour({
         id: 'ts4udfrnm7o95ny7e9qbjo3t',
         defaultStepOptions: {
@@ -312,10 +316,6 @@ const shepherdIncludeCode = `
         ],
         useModalOverlay: true
       });
-
-      const element = document.createElement('p');
-      element.innerText =
-        'Including Shepherd is easy! Just include shepherd.js. The styles are bundled with the JS.';
 
       // This should add steps after the ones added with `addSteps`
       shepherd.addStep({

--- a/landing/src/layouts/MainPage.astro
+++ b/landing/src/layouts/MainPage.astro
@@ -182,8 +182,6 @@ const shepherdIncludeCode = `
   'use strict';
 
   import Shepherd from 'shepherd.js';
-  import type { StepOptions } from 'shepherd.js/dist/step';
-  import type { Tour } from 'shepherd.js/dist/tour';
 
   (function () {
     async function init() {
@@ -223,19 +221,93 @@ const shepherdIncludeCode = `
             buttons: [
               {
                 action() {
-                  return (this as unknown as Tour).cancel();
+                  return this.cancel();
                 },
                 secondary: true,
                 text: 'Exit'
               },
               {
                 action() {
-                  return (this as unknown as Tour).next();
+                  return this.next();
                 },
                 text: 'Next'
               }
             ],
             id: 'welcome'
+          },
+          {
+            title: 'Including',
+            text: element,
+            attachTo: {
+              element: '.hero-including',
+              on: 'bottom'
+            },
+            buttons: [
+              {
+                action() {
+                  return this.back();
+                },
+                secondary: true,
+                text: 'Back'
+              },
+              {
+                action() {
+                  return this.next();
+                },
+                text: 'Next'
+              }
+            ],
+            id: 'including'
+          },
+          {
+            title: 'Creating a Shepherd Tour',
+            text:
+              'Creating a Shepherd tour is easy. too! ' +
+              'Just create a `Tour` instance, and add as many steps as you want.',
+            attachTo: {
+              element: '.hero-example',
+              on: 'right'
+            },
+            buttons: [
+              {
+                action() {
+                  return this.back();
+                },
+                secondary: true,
+                text: 'Back'
+              },
+              {
+                action() {
+                  return this.next();
+                },
+                text: 'Next'
+              }
+            ],
+            id: 'creating'
+          },
+          {
+            title: 'Attaching to Elements',
+            text: 'Your tour steps can target and attach to elements in DOM (like this step).',
+            attachTo: {
+              element: '.hero-example',
+              on: 'left'
+            },
+            buttons: [
+              {
+                action() {
+                  return this.back();
+                },
+                secondary: true,
+                text: 'Back'
+              },
+              {
+                action() {
+                  return this.next();
+                },
+                text: 'Next'
+              }
+            ],
+            id: 'attaching'
           }
         ],
         useModalOverlay: true
@@ -245,86 +317,6 @@ const shepherdIncludeCode = `
       element.innerText =
         'Including Shepherd is easy! Just include shepherd.js. The styles are bundled with the JS.';
 
-      // These steps should be added via `addSteps`
-      const steps = [
-        {
-          title: 'Including',
-          text: element,
-          attachTo: {
-            element: '.hero-including',
-            on: 'bottom'
-          },
-          buttons: [
-            {
-              action() {
-                return (this as unknown as Tour).back();
-              },
-              secondary: true,
-              text: 'Back'
-            },
-            {
-              action() {
-                return (this as unknown as Tour).next();
-              },
-              text: 'Next'
-            }
-          ],
-          id: 'including'
-        },
-        {
-          title: 'Creating a Shepherd Tour',
-          text:
-            'Creating a Shepherd tour is easy. too! ' +
-            'Just create a `Tour` instance, and add as many steps as you want.',
-          attachTo: {
-            element: '.hero-example',
-            on: 'right'
-          },
-          buttons: [
-            {
-              action() {
-                return (this as unknown as Tour).back();
-              },
-              secondary: true,
-              text: 'Back'
-            },
-            {
-              action() {
-                return (this as unknown as Tour).next();
-              },
-              text: 'Next'
-            }
-          ],
-          id: 'creating'
-        },
-        {
-          title: 'Attaching to Elements',
-          text: 'Your tour steps can target and attach to elements in DOM (like this step).',
-          attachTo: {
-            element: '.hero-example',
-            on: 'left'
-          },
-          buttons: [
-            {
-              action() {
-                return (this as unknown as Tour).back();
-              },
-              secondary: true,
-              text: 'Back'
-            },
-            {
-              action() {
-                return (this as unknown as Tour).next();
-              },
-              text: 'Next'
-            }
-          ],
-          id: 'attaching'
-        }
-      ] as StepOptions[];
-      // @ts-ignore
-      shepherd.addSteps(steps);
-
       // This should add steps after the ones added with `addSteps`
       shepherd.addStep({
         title: 'Centered Shepherd Element',
@@ -332,14 +324,14 @@ const shepherdIncludeCode = `
         buttons: [
           {
             action() {
-              return (this as unknown as Tour).back();
+              return this.back();
             },
             secondary: true,
             text: 'Back'
           },
           {
             action() {
-              return (this as unknown as Tour).next();
+              return this.next();
             },
             text: 'Next'
           }
@@ -357,14 +349,14 @@ const shepherdIncludeCode = `
         buttons: [
           {
             action() {
-              return (this as unknown as Tour).back();
+              return this.back();
             },
             secondary: true,
             text: 'Back'
           },
           {
             action() {
-              return (this as unknown as Tour).next();
+              return this.next();
             },
             text: 'Done'
           }

--- a/landing/src/layouts/MainPage.astro
+++ b/landing/src/layouts/MainPage.astro
@@ -182,8 +182,8 @@ const shepherdIncludeCode = `
   'use strict';
 
   import Shepherd from 'shepherd.js';
-  import type { StepOptions } from 'shepherd.js/step';
-  import type { Tour } from 'shepherd.js/tour';
+  import type { StepOptions } from 'shepherd.js/dist/step';
+  import type { Tour } from 'shepherd.js/dist/tour';
 
   (function () {
     async function init() {
@@ -246,7 +246,7 @@ const shepherdIncludeCode = `
         'Including Shepherd is easy! Just include shepherd.js. The styles are bundled with the JS.';
 
       // These steps should be added via `addSteps`
-      const steps: Array<StepOptions> = [
+      const steps = [
         {
           title: 'Including',
           text: element,
@@ -321,8 +321,8 @@ const shepherdIncludeCode = `
           ],
           id: 'attaching'
         }
-      ];
-
+      ] as StepOptions[];
+      // @ts-ignore
       shepherd.addSteps(steps);
 
       // This should add steps after the ones added with `addSteps`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,9 +209,6 @@ importers:
       idb:
         specifier: ^8.0.0
         version: 8.0.0
-      rollup-plugin-dts:
-        specifier: ^6.1.0
-        version: 6.1.0(rollup@4.17.2)(typescript@5.4.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -273,6 +270,9 @@ importers:
       rollup-plugin-analyzer:
         specifier: ^4.0.0
         version: 4.0.0
+      rollup-plugin-copy:
+        specifier: ^3.5.0
+        version: 3.5.0
       rollup-plugin-filesize:
         specifier: ^10.0.0
         version: 10.0.0
@@ -4367,9 +4367,22 @@ packages:
   /@types/estree@1.0.5:
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
+  /@types/fs-extra@8.1.5:
+    resolution: {integrity: sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==}
+    dependencies:
+      '@types/node': 20.12.7
+    dev: true
+
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
+      '@types/node': 20.12.7
+    dev: true
+
+  /@types/glob@7.2.0:
+    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
+    dependencies:
+      '@types/minimatch': 3.0.5
       '@types/node': 20.12.7
     dev: true
 
@@ -6352,6 +6365,10 @@ packages:
 
   /colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+    dev: true
+
+  /colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
     dev: true
 
   /colorette@2.0.20:
@@ -8502,6 +8519,20 @@ packages:
       define-properties: 1.2.1
     dev: true
 
+  /globby@10.0.1:
+    resolution: {integrity: sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/glob': 7.2.0
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.2
+      glob: 7.2.3
+      ignore: 5.3.1
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: true
+
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -9535,6 +9566,11 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
     dev: false
+
+  /is-plain-object@3.0.1:
+    resolution: {integrity: sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
 
   /is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -14574,19 +14610,16 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: true
 
-  /rollup-plugin-dts@6.1.0(rollup@4.17.2)(typescript@5.4.5):
-    resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      rollup: ^3.29.4 || ^4
-      typescript: ^4.5 || ^5.0
+  /rollup-plugin-copy@3.5.0:
+    resolution: {integrity: sha512-wI8D5dvYovRMx/YYKtUNt3Yxaw4ORC9xo6Gt9t22kveWz1enG9QrhVlagzwrxSC455xD1dHMKhIJkbsQ7d48BA==}
+    engines: {node: '>=8.3'}
     dependencies:
-      magic-string: 0.30.10
-      rollup: 4.17.2
-      typescript: 5.4.5
-    optionalDependencies:
-      '@babel/code-frame': 7.24.2
-    dev: false
+      '@types/fs-extra': 8.1.5
+      colorette: 1.4.0
+      fs-extra: 8.1.0
+      globby: 10.0.1
+      is-plain-object: 3.0.1
+    dev: true
 
   /rollup-plugin-filesize@10.0.0:
     resolution: {integrity: sha512-JAYYhzCcmGjmCzo3LEHSDE3RAPHKIeBdpqRhiyZSv5o/3wFhktUOzYAWg/uUKyEu5dEaVaql6UOmaqHx1qKrZA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       idb:
         specifier: ^8.0.0
         version: 8.0.0
+      rollup-plugin-dts:
+        specifier: ^6.1.0
+        version: 6.1.0(rollup@4.17.2)(typescript@5.4.5)
     devDependencies:
       '@babel/core':
         specifier: ^7.24.5
@@ -14570,6 +14573,20 @@ packages:
     resolution: {integrity: sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==}
     engines: {node: '>=8.0.0'}
     dev: true
+
+  /rollup-plugin-dts@6.1.0(rollup@4.17.2)(typescript@5.4.5):
+    resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      rollup: ^3.29.4 || ^4
+      typescript: ^4.5 || ^5.0
+    dependencies:
+      magic-string: 0.30.10
+      rollup: 4.17.2
+      typescript: 5.4.5
+    optionalDependencies:
+      '@babel/code-frame': 7.24.2
+    dev: false
 
   /rollup-plugin-filesize@10.0.0:
     resolution: {integrity: sha512-JAYYhzCcmGjmCzo3LEHSDE3RAPHKIeBdpqRhiyZSv5o/3wFhktUOzYAWg/uUKyEu5dEaVaql6UOmaqHx1qKrZA==}

--- a/shepherd.js/.eslintignore
+++ b/shepherd.js/.eslintignore
@@ -1,1 +1,2 @@
 /dist/
+/scripts/

--- a/shepherd.js/package.json
+++ b/shepherd.js/package.json
@@ -55,8 +55,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.5.3",
     "deepmerge-ts": "^5.1.0",
-    "idb": "^8.0.0",
-    "rollup-plugin-dts": "^6.1.0"
+    "idb": "^8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",
@@ -79,6 +78,7 @@
     "rimraf": "^5.0.5",
     "rollup": "^4.17.2",
     "rollup-plugin-analyzer": "^4.0.0",
+    "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-license": "^3.3.1",
     "rollup-plugin-livereload": "^2.0.5",

--- a/shepherd.js/package.json
+++ b/shepherd.js/package.json
@@ -18,20 +18,19 @@
     "Robbie Wagner <rwwagner90@gmail.com>",
     "Chuck Carpenter <chuck@shipshape.io>"
   ],
+  "main": "dist/shepherd.js",
+  "module": "dist/shepherd.mjs",
   "exports": {
     ".": {
-      "types": "./dist/shepherd.d.ts",
-      "require": "./dist/shepherd.js",
       "import": "./dist/shepherd.mjs",
-      "default": "./dist/shepherd.js"
+      "require": "./dist/shepherd.js"
     },
     "./*": {
-      "types": "./dist/*.d.ts",
-      "require": "./dist/*.js",
       "import": "./dist/*.mjs",
-      "default": "./dist/*.js"
+      "require": "./dist/*.js"
     }
   },
+  "types": "shepherd.d.ts",
   "typesVersions": {
     "*": {
       "*": [
@@ -40,7 +39,7 @@
     }
   },
   "scripts": {
-    "build": "pnpm clean && rollup -c",
+    "build": "pnpm clean && rollup -c && node scripts/postprocess.js",
     "clean": "rimraf ./dist",
     "esdoc": "esdoc",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
@@ -56,7 +55,8 @@
   "dependencies": {
     "@floating-ui/dom": "^1.5.3",
     "deepmerge-ts": "^5.1.0",
-    "idb": "^8.0.0"
+    "idb": "^8.0.0",
+    "rollup-plugin-dts": "^6.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/shepherd.js/rollup.config.mjs
+++ b/shepherd.js/rollup.config.mjs
@@ -2,7 +2,7 @@ import autoprefixer from 'autoprefixer';
 import fs from 'fs';
 import cssnanoPlugin from 'cssnano';
 import { babel } from '@rollup/plugin-babel';
-import dts from 'rollup-plugin-dts';
+import copy from 'rollup-plugin-copy';
 import serve from 'rollup-plugin-serve';
 import livereload from 'rollup-plugin-livereload';
 import filesize from 'rollup-plugin-filesize';
@@ -46,7 +46,18 @@ const plugins = [
     banner
   }),
   filesize(),
-  visualizer()
+  visualizer(),
+  copy({
+    targets: [
+      {
+        src: 'dist/shepherd.d.ts',
+        dest: 'dist',
+        rename: 'shepherd.d.mts'
+      }
+    ],
+    copySync: true,
+    hook: 'writeBundle' // Ensure copying happens after the build is complete
+  })
 ];
 
 // If we are running with --environment DEVELOPMENT, serve via browsersync for local development
@@ -77,30 +88,5 @@ export default [
       }
     ],
     plugins
-  },
-  {
-    input: 'src/shepherd.ts',
-    output: { file: 'dist/shepherd.d.mts', format: 'es' },
-    plugins: [
-      dts({
-        compilerOptions: {
-          emitDeclarationOnly: true
-        }
-      })
-    ]
-  },
-  {
-    input: 'src/shepherd.ts',
-    output: { file: 'dist/shepherd.d.ts', format: 'cjs' },
-    plugins: [
-      dts({
-        compilerOptions: {
-          emitDeclarationOnly: true,
-          module: 'CommonJS',
-          esModuleInterop: false,
-          verbatimModuleSyntax: false,
-        }
-      })
-    ]
   }
 ];

--- a/shepherd.js/rollup.config.mjs
+++ b/shepherd.js/rollup.config.mjs
@@ -2,6 +2,7 @@ import autoprefixer from 'autoprefixer';
 import fs from 'fs';
 import cssnanoPlugin from 'cssnano';
 import { babel } from '@rollup/plugin-babel';
+import dts from 'rollup-plugin-dts';
 import serve from 'rollup-plugin-serve';
 import livereload from 'rollup-plugin-livereload';
 import filesize from 'rollup-plugin-filesize';
@@ -71,9 +72,35 @@ export default [
         dir: 'dist',
         entryFileNames: '[name].js',
         format: 'cjs',
-        sourcemap: true
+        sourcemap: true,
+        exports: 'auto'
       }
     ],
     plugins
+  },
+  {
+    input: 'src/shepherd.ts',
+    output: { file: 'dist/shepherd.d.mts', format: 'es' },
+    plugins: [
+      dts({
+        compilerOptions: {
+          emitDeclarationOnly: true
+        }
+      })
+    ]
+  },
+  {
+    input: 'src/shepherd.ts',
+    output: { file: 'dist/shepherd.d.ts', format: 'cjs' },
+    plugins: [
+      dts({
+        compilerOptions: {
+          emitDeclarationOnly: true,
+          module: 'CommonJS',
+          esModuleInterop: false,
+          verbatimModuleSyntax: false,
+        }
+      })
+    ]
   }
 ];

--- a/shepherd.js/scripts/postprocess.js
+++ b/shepherd.js/scripts/postprocess.js
@@ -3,8 +3,5 @@ const path = require('path');
 
 const declarationFile = path.join(__dirname, '../dist', 'shepherd.d.ts');
 let content = fs.readFileSync(declarationFile, 'utf8');
-content = content.replace(
-  /export { Shepherd as default }/g,
-  'export = Shepherd'
-);
+content = content.replace(/export default Shepherd/g, 'export = Shepherd');
 fs.writeFileSync(declarationFile, content);

--- a/shepherd.js/scripts/postprocess.js
+++ b/shepherd.js/scripts/postprocess.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const declarationFile = path.join(__dirname, '../dist', 'shepherd.d.ts');
+let content = fs.readFileSync(declarationFile, 'utf8');
+content = content.replace(
+  /export { Shepherd as default }/g,
+  'export = Shepherd'
+);
+fs.writeFileSync(declarationFile, content);

--- a/shepherd.js/src/step.ts
+++ b/shepherd.js/src/step.ts
@@ -355,6 +355,7 @@ export class Step extends Evented {
    * Hide the step
    */
   hide() {
+    // @ts-expect-error TODO: investigate once Svelte is typed to use Modal component
     this.tour.modal?.hide();
 
     this.trigger('before-hide');
@@ -580,7 +581,7 @@ export class Step extends Evented {
     if (!this.tour.modal) {
       this.tour.setupModal();
     }
-
+    // @ts-expect-error TODO: investigate once Svelte is typed to use Modal component
     this.tour.modal?.setupForStep(this);
     this._styleTargetElementForStep(this);
 

--- a/shepherd.js/src/tour.ts
+++ b/shepherd.js/src/tour.ts
@@ -193,7 +193,7 @@ export class Tour extends Evented {
   currentStep?: Step | null;
   focusedElBeforeOpen?: HTMLElement | null;
   id?: string;
-  modal?: ShepherdModal;
+  modal?: Record<string, unknown> | null;
   options: TourOptions;
   steps: Array<Step>;
 
@@ -502,6 +502,7 @@ export class Tour extends Evented {
     this.trigger('inactive', { tour: this });
 
     if (this.modal) {
+      // @ts-expect-error TODO: investigate once Svelte is typed
       this.modal.hide();
     }
 

--- a/shepherd.js/tsconfig.json
+++ b/shepherd.js/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "target": "es2021",
-    "module": "esnext",
-    "moduleResolution": "bundler",
+    "target": "es2020",
+    "module": "es2020",
+    "moduleResolution": "node",
     // We don't want to include types dependencies in our compiled output, so tell TypeScript
     // to enforce using `import type` instead of `import` for Types.
     "verbatimModuleSyntax": true,
@@ -43,6 +43,6 @@
       "src/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "src/**/*.svelte"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
closes #2785 

![image](https://github.com/shepherd-pro/shepherd/assets/706378/f6966e56-ffa9-4cba-b6d4-b7e255ea0077)

The issues with imports were due to `.svelte` imports in the declarations files and that not resolving correctly (workaround for now but just using `Record`) and the need for two declarations files for both cjs and esm. 
