### PR TITLE
🐛 Add small padding to arrow if edge alignment is used

### DIFF
--- a/shepherd.js/src/utils/floating-ui.ts
+++ b/shepherd.js/src/utils/floating-ui.ts
@@ -191,7 +191,12 @@ export function getFloatingUIOptions(
     );
 
     if (arrowEl) {
-      options.middleware.push(arrow({ element: arrowEl }));
+      const hasEdgeAlignment =
+        attachToOptions?.on?.includes('-start') ||
+        attachToOptions?.on?.includes('-end');
+      options.middleware.push(
+        arrow({ element: arrowEl, padding: hasEdgeAlignment ? 4 : 0 })
+      );
     }
 
     options.placement = attachToOptions.on;


### PR DESCRIPTION
provides a more edge aligned default with Shepherd.js default styles

before: 
![image](https://github.com/shepherd-pro/shepherd/assets/706378/6d4efe64-4ef7-46d4-a546-8bd173f75920)


after: 
![image](https://github.com/shepherd-pro/shepherd/assets/706378/0b25aeef-373b-4af1-a453-5a1771e0095a)


closes #2315 #2302 #1560 